### PR TITLE
Add a comment about the ADFS_ADMIN_GROUP

### DIFF
--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -142,7 +142,8 @@ export SAML_KEYSTORE_ACCOUNT_NAME=""
 export KEY_VAULT_NAME=""
 
 # REQUIRED
-# The ADFS group name for specifying CiviForm admins.
+# The ADFS group name for specifying CiviForm admins. If usinge
+# Azure AD this is the group's object ID
 export ADFS_ADMIN_GROUP=""
 
 # REQUIRED


### PR DESCRIPTION
Azure AD emits the groups claim as the object id and not the group name (in ADFS you can configure it to be the group name) so adding that as a comment here