### PR TITLE
Adding a run command

### DIFF
--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -8,7 +8,8 @@
 # tag the user specifies in the command.
 
 #######################################
-# Delegates a command to the main CiviForm repo at a specific git revision.
+# Delegates a command from a specified path to the main CiviForm repo at a 
+# specific git revision.
 # Expects arguments to include "--tag=<tag name>" for resolving which revsion
 # to check out for the command. Then passes all arguments to the delegated
 # command in the main repo.
@@ -17,8 +18,8 @@
 # Globals:
 #   CMD_NAME: the name of the command to run
 #######################################
-function checkout::exec_delegated_command() {
-  if [[ -z "${CMD_NAME}" ]]; then
+function checkout::exec_delegated_command_at_path() {
+  if [[ -z "${CMD_NAME_PATH}" ]]; then
     out::error "CMD_NAME must be set for delegated command."
     exit 1
   fi
@@ -29,8 +30,24 @@ function checkout::exec_delegated_command() {
 
   (
     cd checkout
-    exec "cloud/shared/bin/${CMD_NAME}" "$@"
+    exec "${CMD_NAME_PATH}" "$@"
   )
+}
+
+#######################################
+# Delegates a command from the shared bin to the main CiviForm repo at a 
+# specific git revision.
+# Expects arguments to include "--tag=<tag name>" for resolving which revsion
+# to check out for the command. Then passes all arguments to the delegated
+# command in the main repo.
+# Arguments:
+#   @: arguments for the command, must include --tag= flag
+# Globals:
+#   CMD_NAME: the name of the command to run
+#######################################
+function checkout::exec_delegated_command() {
+  CMD_NAME_PATH="cloud/shared/bin/${CMD_NAME}" \
+    checkout::exec_delegated_command_at_path "$@"
 }
 
 #######################################

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+# DOC: Run a command at a path. Usage: bin/run <path/to/command> --tag=<image tag>
+
+source bin/lib.sh
+source civiform_config.sh
+
+readonly command_path="${1}"
+shift 1
+
+CMD_NAME_PATH="${command_path}" checkout::exec_delegated_command_at_path "$@"


### PR DESCRIPTION
Runs a command at any path in the cloud repo from the top level dir; useful if you are doing break glass scripts.