### PR TITLE
Fix doctor command when using docker.

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -10,7 +10,7 @@ source bin/lib.sh
 source ${CONFIG}
 
 if [[ ! -z "${USE_DOCKER}" ]]; then
-    COMMAND="doctor"
+    export COMMAND="doctor"
     exec "bin/lib/run_from_docker"
 else 
     CMD_NAME=doctor checkout::exec_delegated_command "$@"


### PR DESCRIPTION
Current behavior:

```
$ USE_DOCKER=true bin/doctor --tag=latest
Using config file civiform_config.sh
Using civiform/civiform-cloud-deployment:latest
Running:  --tag=latest --config=civiform_config.sh
Do you want to proceed? [y/N] y
WARN[0000] The "COMMAND" variable is not set. Defaulting to a blank string.
```

Doctor is the only command missing the export:

```
$ git reset --hard origin/main
HEAD is now at 52442ba Make configs work with new repo and docker (#25)
$ grep -R USE_DOCKER -A 1 bin
bin/deploy:if [[ ! -z "${USE_DOCKER}" ]]; then
bin/deploy-    export COMMAND="deploy"
--
bin/doctor:if [[ ! -z "${USE_DOCKER}" ]]; then
bin/doctor-    COMMAND="doctor"
--
bin/run:if [[ ! -z "${USE_DOCKER}" ]]; then
bin/run-    export COMMAND="${command_path}"
--
bin/setup:if [[ ! -z "${USE_DOCKER}" ]]; then
bin/setup-    export COMMAND="setup"
```

Still need to update the doctor command with docker-specific considerations as mentioned in https://github.com/civiform/civiform/issues/3544.