### PR TITLE
Expose port 9000 to localhost

### DIFF
--- a/bin/lib/docker-compose.yaml
+++ b/bin/lib/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   cloud:
     stdin_open: true # docker run -i
     tty: true        # docker run -t
+    ports:
+      - 9000:9000
     image: civiform/civiform-cloud-deployment:${CIVIFORM_CLOUD_DEPLOYMENT_VERSION}
     environment:
       - AWS_ACCESS_KEY_ID

--- a/bin/lib/run_from_docker
+++ b/bin/lib/run_from_docker
@@ -24,4 +24,4 @@ if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
   exit
 fi
 
-docker compose -f bin/lib/docker-compose.yaml --service-ports run --rm cloud
+docker compose -f bin/lib/docker-compose.yaml run --service-ports --rm cloud

--- a/bin/lib/run_from_docker
+++ b/bin/lib/run_from_docker
@@ -24,4 +24,4 @@ if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
   exit
 fi
 
-docker compose -f bin/lib/docker-compose.yaml run --rm cloud
+docker compose -f bin/lib/docker-compose.yaml --service-ports run --rm cloud


### PR DESCRIPTION
This allows us to run https://github.com/im2nguyen/rover from inside docker and view the results in a web browser.

Rover command support added in https://github.com/civiform/cloud-deploy-infra/pull/76.