### PR TITLE
Store civiform server version in civiform_config.sh

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
-# DOC: Deploy an image. Usage: bin/deploy --tag=<image tag> 
+# DOC: Deploy an image. Usage: bin/deploy
+
 # Optional params:
 #   --config=<config_file> to override config file
 

--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -33,11 +33,11 @@ function checkout::exec_delegated_command_at_path() {
   fi
 
   if [[ -z "${CIVIFORM_VERSION}" ]]; then
-    out:error "CIVIFORM_VERSION needs to be either 'latest' or a version from https://github.com/civiform/civiform/releases"
+    out::error "CIVIFORM_VERSION needs to be either 'latest' or a version from https://github.com/civiform/civiform/releases"
     exit 1
   fi
   if [[ "${CIVIFORM_VERSION}" == 'latest' && "${CIVIFORM_MODE}" == 'prod' ]]; then
-    out:error "For production deployments, CIVIFORM_VERSION needs to be a version from https://github.com/civiform/civiform/releases"
+    out::error "For production deployments, CIVIFORM_VERSION needs to be a version from https://github.com/civiform/civiform/releases"
     exit 1
   fi
 

--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -32,6 +32,15 @@ function checkout::exec_delegated_command_at_path() {
     checkout::at_sha "${CIVIFORM_CLOUD_DEPLOYMENT_VERSION}"
   fi
 
+  if [[ -z "${CIVIFORM_VERSION}" ]]; then
+    out:error "CIVIFORM_VERSION needs to be either 'latest' or a version from https://github.com/civiform/civiform/releases"
+    exit 1
+  fi
+  if [[ "${CIVIFORM_VERSION}" == 'latest' && "${CIVIFORM_MODE}" == 'prod' ]]; then
+    out:error "For production deployments, CIVIFORM_VERSION needs to be a version from https://github.com/civiform/civiform/releases"
+    exit 1
+  fi
+
   (
     cd checkout
     CONFIG_FILE_ABSOLUTE_PATH="../${CONFIG}" \

--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -35,7 +35,7 @@ function checkout::exec_delegated_command_at_path() {
   (
     cd checkout
     CONFIG_FILE_ABSOLUTE_PATH="../${CONFIG}" \
-    args=("--command=${CMD_NAME}" "--tag=${IMAGE_TAG}" "--config=${CONFIG_FILE_ABSOLUTE_PATH}")
+    args=("--command=${CMD_NAME}" "--tag=${CIVIFORM_VERSION}" "--config=${CONFIG_FILE_ABSOLUTE_PATH}")
     echo "Running ${CMD_NAME_PATH} ${args[@]}"
     exec "${CMD_NAME_PATH}" "${args[@]}"
   )

--- a/bin/lib/docker-compose.yaml
+++ b/bin/lib/docker-compose.yaml
@@ -13,9 +13,9 @@ services:
       - AZURE_LOCAL_CONNECTION_STRING
       - AZURE_STORAGE_ACCOUNT_CONTAINER
       - CONFIG
-      - IMAGE_TAG
+      - CIVIFORM_VERSION
       - COMMAND
     volumes:
       # Mounting civiform config to the image in read only mode.
       - ${PWD}/${CONFIG}:/${CONFIG}:ro
-    command: cloud/shared/bin/run.py --tag=${IMAGE_TAG} --command="${COMMAND}" --config=${CONFIG}
+    command: cloud/shared/bin/run.py --tag="${CIVIFORM_VERSION}" --command="${COMMAND}" --config=${CONFIG}

--- a/bin/lib/get_cmd_args.sh
+++ b/bin/lib/get_cmd_args.sh
@@ -1,28 +1,6 @@
 #! /usr/bin/env bash
 
 #######################################
-# Retrieves the image tag from a list of aguments.
-# Exits with an error message if --tag flag is not found.
-# Arguments:
-#   @: An arguments list
-# Globals:
-#   Sets the IMAGE_TAG variable
-#######################################
-function get_cmd_args::get_image_tag() {
-  for i in "$@"; do
-    case "${i}" in
-      --tag=*)
-        export IMAGE_TAG="${i#*=}"
-        return
-        ;;
-    esac
-  done
-
-  out::error "--tag argument is required"
-  exit 1
-}
-
-#######################################
 # Retrieves the config file name from a list of aguments if present.
 # Arguments:
 #   @: An arguments list
@@ -42,5 +20,4 @@ function get_cmd_args::get_config_file() {
   export CONFIG="civiform_config.sh"
 }
 
-get_cmd_args::get_image_tag "$@"
 get_cmd_args::get_config_file "$@"

--- a/bin/lib/run_from_docker
+++ b/bin/lib/run_from_docker
@@ -15,6 +15,10 @@ if [[ -z "${CIVIFORM_VERSION}" ]]; then
   echo "CIVIFORM_VERSION needs to be set to version from https://github.com/civiform/civiform/releases"
   exit 1
 fi
+if [[ "${CIVIFORM_VERSION}" == 'latest' && "${CIVIFORM_MODE}" == 'prod' ]]; then
+  echo "Production deployments are required to specify a specific version from https://github.com/civiform/civiform/releases"
+  exit 1
+fi
 
 if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
   export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)

--- a/bin/lib/run_from_docker
+++ b/bin/lib/run_from_docker
@@ -11,6 +11,11 @@ if [[ -z "${CIVIFORM_CLOUD_DEPLOYMENT_VERSION}" ]]; then
   exit 1
 fi
 
+if [[ -z "${CIVIFORM_VERSION}" ]]; then
+  echo "CIVIFORM_VERSION needs to be set to version from https://github.com/civiform/civiform/releases"
+  exit 1
+fi
+
 if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
   export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
 fi
@@ -18,7 +23,7 @@ if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
   export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
 fi
 echo "Using civiform/civiform-cloud-deployment:${CIVIFORM_CLOUD_DEPLOYMENT_VERSION}"
-echo "Running: ${COMMAND} --tag=${IMAGE_TAG} --config=${CONFIG}"
+echo "Running: ${COMMAND} --tag=${CIVIFORM_VERSION} --config=${CONFIG}"
 read -r -p "Do you want to proceed? [y/N] " response
 if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
   exit

--- a/bin/lib/run_from_docker
+++ b/bin/lib/run_from_docker
@@ -12,11 +12,11 @@ if [[ -z "${CIVIFORM_CLOUD_DEPLOYMENT_VERSION}" ]]; then
 fi
 
 if [[ -z "${CIVIFORM_VERSION}" ]]; then
-  echo "CIVIFORM_VERSION needs to be set to version from https://github.com/civiform/civiform/releases"
+  echo "CIVIFORM_VERSION needs to be either 'latest' or a version from https://github.com/civiform/civiform/releases"
   exit 1
 fi
 if [[ "${CIVIFORM_VERSION}" == 'latest' && "${CIVIFORM_MODE}" == 'prod' ]]; then
-  echo "Production deployments are required to specify a specific version from https://github.com/civiform/civiform/releases"
+  echo "For production deployments, CIVIFORM_VERSION needs to be a version from https://github.com/civiform/civiform/releases"
   exit 1
 fi
 

--- a/bin/run
+++ b/bin/run
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
-# DOC: Run a command at a path. Usage: bin/run --tag=<image tag>
+# DOC: Run a command at a path. Usage: bin/run
+
 # It will ask for keyboard input for the command to run.
 # Optional params:
 #   --config=<config_file> to override config file

--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -15,6 +15,10 @@
 #################################################
 
 # REQUIRED
+# One of prod, staging, or dev.
+export CIVIFORM_MODE="staging"
+
+# REQUIRED
 # Version of the infrastructure to use.
 # Needs to be either:
 # - Label from https://hub.docker.com/r/civiform/civiform-cloud-deployment if USE_DOCKER=true
@@ -24,12 +28,11 @@
 export CIVIFORM_CLOUD_DEPLOYMENT_VERSION="latest"
 
 # REQUIRED
-# Version of the CiviForm server to use.
-# Needs to be either:
-# - A version from https://github.com/civiform/civiform/releases.
-# - "latest" to use the latest CiviForm version available. This is only
-#   recommended for staging environments.
-export CIVIFORM_VERSION="v1.8.2"
+# CiviForm server version to deploy.
+#
+# For dev and staging civiform modes, can be "latest". For prod, must be a version from
+# https://github.com/civiform/civiform/releases.
+export CIVIFORM_VERSION="latest"
 
 # Terraform configuration
 #################################################
@@ -39,9 +42,6 @@ export CIVIFORM_VERSION="v1.8.2"
 # "aws" or "azure"
 export CIVIFORM_CLOUD_PROVIDER="aws"
 
-# REQUIRED
-# One of prod, staging, or dev.
-export CIVIFORM_MODE="staging"
 
 # REQUIRED
 # The template directory for this deployment.

--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -19,20 +19,22 @@
 export CIVIFORM_MODE="staging"
 
 # REQUIRED
+# CiviForm server version to deploy.
+#
+# For dev and staging civiform modes, can be "latest". For prod, must be a version from
+# https://github.com/civiform/civiform/releases, for example "v1.2.3".
+export CIVIFORM_VERSION="latest"
+
+# REQUIRED
 # Version of the infrastructure to use.
 # Needs to be either:
 # - Label from https://hub.docker.com/r/civiform/civiform-cloud-deployment if USE_DOCKER=true
 # - Commit sha from https://github.com/civiform/cloud-deploy-infra if USE_DOCKER=false
 # - "latest" to use latest version of either docker image or code from the repo, 
 #    depending on USE_DOCKER flag.
-export CIVIFORM_CLOUD_DEPLOYMENT_VERSION="latest"
-
-# REQUIRED
-# CiviForm server version to deploy.
 #
-# For dev and staging civiform modes, can be "latest". For prod, must be a version from
-# https://github.com/civiform/civiform/releases.
-export CIVIFORM_VERSION="latest"
+# Using "latest" is recommended.
+export CIVIFORM_CLOUD_DEPLOYMENT_VERSION="latest"
 
 # Terraform configuration
 #################################################

--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -25,7 +25,10 @@ export CIVIFORM_CLOUD_DEPLOYMENT_VERSION="latest"
 
 # REQUIRED
 # Version of the CiviForm server to use.
-# Needs to be a version from https://github.com/civiform/civiform/releases.
+# Needs to be either:
+# - A version from https://github.com/civiform/civiform/releases.
+# - "latest" to use the latest CiviForm version available. This is only
+#   recommended for staging environments.
 export CIVIFORM_VERSION="v1.8.2"
 
 # Terraform configuration

--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -21,8 +21,12 @@
 # - Commit sha from https://github.com/civiform/cloud-deploy-infra if USE_DOCKER=false
 # - "latest" to use latest version of either docker image or code from the repo, 
 #    depending on USE_DOCKER flag.
-
 export CIVIFORM_CLOUD_DEPLOYMENT_VERSION="latest"
+
+# REQUIRED
+# Version of the CiviForm server to use.
+# Needs to be a version from https://github.com/civiform/civiform/releases.
+export CIVIFORM_VERSION="v1.8.2"
 
 # Terraform configuration
 #################################################


### PR DESCRIPTION
Explicitly store the desired CiviForm server version in `civiform_config.sh`.

The workflow for upgrading CiviForm server version changes from running `bin/deploy --tag=<new_version>` to:

1. Update the `CIVIFORM_VERSION` value in `civiform_config.sh`.
2. Run `bin/deploy`.



This change is supported by both tactical and engineering excellence arguments arguments:

### Tactical

- The pgadmin command (https://github.com/civiform/cloud-deploy-infra/pull/79) implementation benefits from this change.  Currently if an IT administrator wants to deploy the pgadmin service, they need to know the most-recently-deployed CiviForm server version in order to not accidentally change the CiviForm server while turning up the pgadmin service.

### Engineering excellence

- Currently, the idempotency of the deploy command is subject to human error because IT administrators need to manually remember what CiviForm version they have most recently deployed (need to correctly pass in the same value to `--tag` for multiple runs of the deploy system to be idempotent). 
- The CiviForm server version is currently the only option passed in via a command line arguments to the deploy tool. 
 Configuring it via the `civiform_config.sh` is more consistent with the rest of the configuration.
- Simplifies change controls/automation if IT departments wish to implement them.  An example process could be:

   1. Update `CIVIFORM_VERSION`, get approval via a code review.
   2. After approval, merge the change.
   3. Automation runs `bin/deploy` with the updated `civiform_config.sh` file.