### PR TITLE
Add nuke.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ civiform_config.sh
 .idea
 *.log
 tmp/
-
+nuke.yaml
 checkout/

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ civiform_config.sh
 .idea
 *.log
 tmp/
-nuke.yaml
+nuke.yaml     # this file is created by developers when working on the deployment system. see https://docs.civiform.us/contributor-guide/developer-guide/deploy-system/prerequisites#setup-aws-nuke
 checkout/


### PR DESCRIPTION
This PR adds `nuke.yaml` to the `.gitignore` file so devs can safely keep the file in the root folder without worrying about accidentally pushing changes to git.

Corresponding change to docs: https://github.com/civiform/docs/pull/267