### PR TITLE
Keep the .venv folder when we delete the checkout folder

### DIFF
--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -77,12 +77,12 @@ function checkout::exec_delegated_command() {
 function checkout::initialize() {
   printf "Initializing checkout... "
 
-    # the checkout directory was getting larger on each run. Remove and re-create
-  # it to avoid the growth, but keep the python virtual environment to avoid 
-  # latency that is added by re-installing python dependencies, such as the
-  # installation of env-var-docs.parser packages.
+  # The checkout directory was getting larger on each run. Remove and re-create
+  # it to avoid the growth. However, keep the python virtual environment files 
+  # in .venv to avoid re-installing python dependencies every time. Re-installation
+  # adds multiple seconds of latency.
   cd checkout
-  find . ! -name "$subfolder_name" ! -name '.' ! -name '..' -exec rm -r {} +
+  find . ! -name ".venv" ! -name '.' ! -name '..' -exec rm -rf {} +
   cd ..
 
   pushd checkout > /dev/null

--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -77,8 +77,13 @@ function checkout::exec_delegated_command() {
 function checkout::initialize() {
   printf "Initializing checkout... "
 
-  rm -rf checkout
-  mkdir checkout
+    # the checkout directory was getting larger on each run. Remove and re-create
+  # it to avoid the growth, but keep the python virtual environment to avoid 
+  # latency that is added by re-installing python dependencies, such as the
+  # installation of env-var-docs.parser packages.
+  cd checkout
+  find . ! -name "$.venv" -exec rm -r {} +
+  cd ..
 
   pushd checkout > /dev/null
 

--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -82,7 +82,7 @@ function checkout::initialize() {
   # latency that is added by re-installing python dependencies, such as the
   # installation of env-var-docs.parser packages.
   cd checkout
-  find . ! -name "$.venv" -exec rm -r {} +
+  find . ! -name "$subfolder_name" ! -name '.' ! -name '..' -exec rm -r {} +
   cd ..
 
   pushd checkout > /dev/null


### PR DESCRIPTION
This is follow up from this PR: https://github.com/civiform/cloud-deploy-infra/pull/147. That PR adds a script that brings up a python virtual environment and installs dependencies from the civiform repository (the env-var-docs.parser).
When the script in #147 is enabled, it will create a .venv directory  where references to the virtual environment and the installed python packages are kept. The installation of the packages takes multiple seconds and is only done if the dependencies are not yet installed in the .venv.

When deployment is started from the deploy repository, the .venv folder ends up in the checkout folder.
Currently the folder is being removed for each run.
This PR ensures that the .venv folder is not removed with the rest of the files to avoid that the virtual environment has to be created again and the packages have to be reinstalled


