### PR TITLE
Revert "Keep the .venv folder when we delete the checkout folder"

### DIFF
--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -77,13 +77,8 @@ function checkout::exec_delegated_command() {
 function checkout::initialize() {
   printf "Initializing checkout... "
 
-  # The checkout directory was getting larger on each run. Remove and re-create
-  # it to avoid the growth. However, keep the python virtual environment files 
-  # in .venv to avoid re-installing python dependencies every time. Re-installation
-  # adds multiple seconds of latency.
-  cd checkout
-  find . ! -name ".venv" ! -name '.' ! -name '..' -exec rm -rf {} +
-  cd ..
+  rm -rf checkout
+  mkdir checkout
 
   pushd checkout > /dev/null
 


### PR DESCRIPTION
Reverts civiform/civiform-deploy#40

See https://github.com/civiform/civiform/issues/4716