### PR TITLE
update comments to reflect correct usage

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# DOC: Check that local environment is ready to run civiform commands. Usage: bin/deploy --tag=<image tag>
+# DOC: Check that local environment is ready to run civiform commands. Usage: bin/deploy
 # Optional params:
 #   --config=<config_file> to override config file
 #   --infra_commit=<commit_sha> to override infrastructure version. 

--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -10,11 +10,9 @@
 #######################################
 # Delegates a command from a specified path to the main CiviForm repo at a 
 # specific git revision.
-# Expects arguments to include "--tag=<tag name>" for resolving which revsion
-# to check out for the command. Then passes all arguments to the delegated
-# command in the main repo.
+# Then passes all arguments to the delegated command in the main repo.
 # Arguments:
-#   @: arguments for the command, must include --tag= flag
+#   @: arguments for the command
 # Globals:
 #   CMD_NAME: the name of the command to run
 #######################################
@@ -33,11 +31,13 @@ function checkout::exec_delegated_command_at_path() {
   fi
 
   if [[ -z "${CIVIFORM_VERSION}" ]]; then
-    out::error "CIVIFORM_VERSION needs to be either 'latest' or a version from https://github.com/civiform/civiform/releases"
+    out::error "CIVIFORM_VERSION needs to be either 'latest', a snapshot tag from https://hub.docker.com/r/civiform/civiform/tags, 
+      or a version from https://github.com/civiform/civiform/releases"
     exit 1
   fi
   if [[ "${CIVIFORM_VERSION}" == 'latest' && "${CIVIFORM_MODE}" == 'prod' ]]; then
-    out::error "For production deployments, CIVIFORM_VERSION needs to be a version from https://github.com/civiform/civiform/releases"
+    out::error "For production deployments, CIVIFORM_VERSION needs to be a version from https://github.com/civiform/civiform/releases 
+      or a snapshot tag from https://hub.docker.com/r/civiform/civiform/tags"
     exit 1
   fi
 
@@ -56,11 +56,9 @@ function checkout::exec_delegated_command_at_path() {
 #######################################
 # Delegates a command from the shared bin to the main CiviForm repo at a 
 # specific git revision.
-# Expects arguments to include "--tag=<tag name>" for resolving which revsion
-# to check out for the command. Then passes all arguments to the delegated
-# command in the main repo.
+# Then passes all arguments to the delegated command in the main repo.
 # Arguments:
-#   @: arguments for the command, must include --tag= flag
+#   @: arguments for the command
 # Globals:
 #   CMD_NAME: the name of the command to run
 #######################################

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# DOC: Set up a new environment. Usage: bin/setup --tag=<image tag>
+# DOC: Set up a new environment. Usage: bin/setup
 # Optional params:
 #   --config=<config_file> to override config file
 

--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -21,8 +21,15 @@ export CIVIFORM_MODE="staging"
 # REQUIRED
 # CiviForm server version to deploy.
 #
-# For dev and staging civiform modes, can be "latest". For prod, must be a version from
-# https://github.com/civiform/civiform/releases, for example "v1.2.3".
+# For dev and staging civiform modes, can be:
+# - "latest"
+# - A specific snapshot tag from https://hub.docker.com/r/civiform/civiform/tags
+# - A version from https://github.com/civiform/civiform/releases, for example "v1.2.3".
+# For prod:
+# - Should usually be a version from https://github.com/civiform/civiform/releases, 
+#   for example "v1.2.3".
+# - In the case where you need to quickly deploy a fix, can also be
+#   specific snapshot tag from https://hub.docker.com/r/civiform/civiform/tags
 export CIVIFORM_VERSION="latest"
 
 # REQUIRED


### PR DESCRIPTION
This pr corrects two outdated explanations of how to use the deploy scripts:
1. `--tag` is no longer used to set the image tag or version of CiviForm to be deployed, that value is set using `CIVIFORM_VERSION` in the config file. 
2. Specific snapshot tags can also be used as the value used for `CIVIFORM_VERSION`