### PR TITLE
Add CLOUD_DEPLOY_INFRA_REMOTE

### DIFF
--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -83,7 +83,8 @@ function checkout::initialize() {
   pushd checkout > /dev/null
 
   git init --initial-branch=main
-  git remote add origin http://github.com/civiform/cloud-deploy-infra
+  CLOUD_DEPLOY_INFRA_REMOTE=${CLOUD_DEPLOY_INFRA_REMOTE:-http:\/\/github.com\/civiform\/cloud-deploy-infra}
+  git remote add origin ${CLOUD_DEPLOY_INFRA_REMOTE}
   git config core.sparseCheckout true
 
   echo "/cloud" >> .git/info/sparse-checkout


### PR DESCRIPTION
This allows you to override the location we are checking out the cloud-deploy-infra repo from, so you can point it to a local version without having to edit the file directly.