### PR TITLE
Add ability to force unlock TF state and fix digest value of lock file in DynamoDB

### DIFF
--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -48,6 +48,9 @@ function checkout::exec_delegated_command_at_path() {
       CONFIG_FILE_ABSOLUTE_PATH="../${CONFIG}"
     fi
     args=("-c${CMD_NAME}" "-t${CIVIFORM_VERSION}" "-s${CONFIG_FILE_ABSOLUTE_PATH}")
+    if [[ -n "${FORCE_UNLOCK_ID}" ]]; then
+      args=("${args[@]}" "-u${FORCE_UNLOCK_ID}")
+    fi
     echo "Running ${CMD_NAME_PATH} ${args[@]}"
     exec "${CMD_NAME_PATH}" "${args[@]}"
   )

--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -48,9 +48,15 @@ function checkout::exec_delegated_command_at_path() {
       CONFIG_FILE_ABSOLUTE_PATH="../${CONFIG}"
     fi
     args=("-c${CMD_NAME}" "-t${CIVIFORM_VERSION}" "-s${CONFIG_FILE_ABSOLUTE_PATH}")
+
     if [[ -n "${FORCE_UNLOCK_ID}" ]]; then
       args=("${args[@]}" "-u${FORCE_UNLOCK_ID}")
     fi
+
+    if [[ -n "${DIGEST_VALUE}" ]]; then
+      args=("${args[@]}" "-d${DIGEST_VALUE}")
+    fi
+    
     echo "Running ${CMD_NAME_PATH} ${args[@]}"
     exec "${CMD_NAME_PATH}" "${args[@]}"
   )

--- a/bin/lib/get_cmd_args.sh
+++ b/bin/lib/get_cmd_args.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 #######################################
-# Retrieves the config file name from a list of aguments if present.
+# Retrieves the config file name from a list of arguments if present.
 # Arguments:
 #   @: An arguments list
 # Globals:
@@ -21,3 +21,16 @@ function get_cmd_args::get_config_file() {
 }
 
 get_cmd_args::get_config_file "$@"
+
+function get_cmd_args::get_force_unlock_id() {
+  for i in "$@"; do
+    case "${i}" in
+      --force-unlock=*)
+        export FORCE_UNLOCK_ID="${i#*=}"
+        return
+        ;;
+      esac
+    done
+}
+
+get_cmd_args::get_force_unlock_id "$@"

--- a/bin/lib/get_cmd_args.sh
+++ b/bin/lib/get_cmd_args.sh
@@ -17,5 +17,8 @@ for i in "$@"; do
     --force-unlock=*)
       export FORCE_UNLOCK_ID="${i#*=}"
       ;;
+    --fix-digest=*)
+      export DIGEST_VALUE="${i#*=}"
+      ;;
   esac
 done

--- a/bin/lib/get_cmd_args.sh
+++ b/bin/lib/get_cmd_args.sh
@@ -1,36 +1,21 @@
 #! /usr/bin/env bash
 
 #######################################
-# Retrieves the config file name from a list of arguments if present.
-# Arguments:
-#   @: An arguments list
-# Globals:
-#   Sets the CONFIG variable
+# Retrieves the value of given flags, if present, and
+# sets a default for some variables if they should have one.
 #######################################
-function get_cmd_args::get_config_file() {
-  for i in "$@"; do
-    case "${i}" in
-      --config=*)
-        export CONFIG="${i#*=}"
-        return
-        ;;
-    esac
-  done
 
-  export CONFIG="civiform_config.sh"
-}
+# Defaults
+export CONFIG="civiform_config.sh"
 
-get_cmd_args::get_config_file "$@"
-
-function get_cmd_args::get_force_unlock_id() {
-  for i in "$@"; do
-    case "${i}" in
-      --force-unlock=*)
-        export FORCE_UNLOCK_ID="${i#*=}"
-        return
-        ;;
-      esac
-    done
-}
-
-get_cmd_args::get_force_unlock_id "$@"
+# Parse flags
+for i in "$@"; do
+  case "${i}" in
+    --config=*)
+      export CONFIG="${i#*=}"
+      ;;
+    --force-unlock=*)
+      export FORCE_UNLOCK_ID="${i#*=}"
+      ;;
+  esac
+done


### PR DESCRIPTION
Sometimes, if a failure occurs or you've Ctrl+C'ed out of the middle of an apply, the Terraform state may be left in a locked state. When this happens, you must run 'terraform force-unlock' with the lock ID to unlock it.

This change detects when an apply results in a lock error, and prompts the user to rerun the command with the --force-unlock flag. It does this by capturing the stderr stream of the 'terraform apply' command to inspect the message if an error occurs. An added bonus is that since we are using Popen to execute the command, we can handle things more gracefully if a user Ctrl+Cs out of the apply and allow Terraform to release the lock, reducing the amount of ways we can get into this failure state.

Secondly, if something goes wrong during deployment, especially when a user has force-unlocked due to a previous issue and then multiple apply actions are happening at once, the digest value for the Terraform lock file in S3 can be incorrect. This lets us set the digest value to the correct value, as given by the error message of a previous Terraform command, without having to go into the AWS console to set it manually.

Requires https://github.com/civiform/cloud-deploy-infra/pull/235
Addresses https://github.com/civiform/civiform/issues/5381