### PR TITLE
CiviForm deployments created from the example configs should be hidden

### DIFF
--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -134,6 +134,10 @@ export CIVIFORM_TIME_ZONE_ID="America/Los_Angeles"
 # Defaults to false.
 # export CIVIFORM_SERVER_METRICS_ENABLED=false
 
+# OPTIONAL
+# Whether to add a robots=noindex meta tag, which causes search engines to not list the website.
+# This can be removed for production deployments that should be searchable.
+export STAGING_ADD_NOINDEX_META_TAG=true
 
 
 ###########################################################################


### PR DESCRIPTION
This change sets the staging_add_noindex_meta_tag flag to true, meaning a deployment created from this example will be hidden by default to prevent dev sites from being searchable.

Related to https://github.com/civiform/civiform/issues/5635