### PR TITLE
Update secret length variable in example config file

### DIFF
--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -252,6 +252,11 @@ export FARGATE_DESIRED_TASK_COUNT=1
 # allowed.
 # export POSTGRES_STORAGE_GB=5
 
+# OPTIONAL
+# Length of the random generated password to use for app_secret_key.
+# Some legacy deployments may be using a shorter length, but going forward 64 will be the default.
+export RANDOM_PASSWORD_LENGTH=64
+
 
 # generic-oidc Auth configuration
 #################################################


### PR DESCRIPTION
https://github.com/civiform/civiform/issues/6506

This will ensure that all deployments going forward have the value we'll need for the play migration  (https://www.playframework.com/documentation/2.9.x/Migration29#Application-Secret-enforces-a-minimum-length)

To be submitted after: https://github.com/civiform/cloud-deploy-infra/pull/285