### PR TITLE
Remove admin writeable vars from civiform_config.example.sh

### DIFF
--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -315,23 +315,6 @@ export APPLICANT_OIDC_MIDDLE_NAME_ATTRIBUTE=""
 export APPLICANT_OIDC_LAST_NAME_ATTRIBUTE=""
 
 # OPTIONAL
-# This setting should *only* be enabled if the applicant identity provider supports the
-# id_token_hint parameter in OIDC logout requests.
-#
-# ADFS: supported
-# Auth0: supported
-# IDCS: supported
-# Login.gov: not supported
-# Okta: required
-#
-# export APPLICANT_OIDC_ENHANCED_LOGOUT_ENABLED="false"
-
-# The name of the authentication provider applicants use to login.
-# This value is displayed to the applicants to help them understand which account to use.
-export APPLICANT_PORTAL_NAME=""
-
-
-# OPTIONAL
 # Identity provider to use to authenticate and authorize admins.
 # Valid values are "adfs" and "generic-oidc-admin". Default is "adfs".
 # export CIVIFORM_ADMIN_IDP="adfs"
@@ -401,15 +384,3 @@ export ADFS_ADMIN_GROUP=""
 # Additional scopes should be retrieved as part of the request to the identity
 # provider. If present, should be space-separated values.
 # export ADMIN_OIDC_ADDITIONAL_SCOPES=""
-
-# OPTIONAL
-# This setting should *only* be enabled if the admin identity provider supports the
-# id_token_hint parameter in OIDC logout requests.
-#
-# ADFS: supported
-# Auth0: supported
-# IDCS: supported
-# Login.gov: not supported
-# Okta: required
-#
-# export ADMIN_OIDC_ENHANCED_LOGOUT_ENABLED="false"


### PR DESCRIPTION
Remove `ADMIN_WRITEABLE` vars from the example config since these should be set in [the admin panel](https://github.com/civiform/civiform/blob/fbc95d34cb6982f0e5a56fa0a4488a57575882cf/env-var-docs/parser-package/README.md?plain=1#L52) and not in the environment.

I need to check the LOGOUT vars with Tom though because we might need those to be set in the config?