### PR TITLE
Add NUM_TRUSTED_PROXIES to example config file

### DIFF
--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -139,6 +139,12 @@ export CIVIFORM_TIME_ZONE_ID="America/Los_Angeles"
 # This can be removed for production deployments that should be searchable.
 export STAGING_ADD_NOINDEX_META_TAG=true
 
+# OPTIONAL
+# The number of reverse proxies between the internet and the server.
+# This value is used to extract the client IP address from HTTP headers.
+# In typical deployments, this value is 1.
+# export NUM_TRUSTED_PROXIES=1
+
 
 ###########################################################################
 # Template variables for Azure. Skip if deploying to other cloud providers.


### PR DESCRIPTION
### Description

Configure the number of trusted proxies to be used when resolving the client IP address.

The variable was introduced in [Allow configurable number of trusted proxies](https://github.com/civiform/civiform/pull/6857).

Primary reviewer: @rockycodes 
FYI: @avaleske 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

### Issue(s) this completes

Fixed #4795.