### PR TITLE
Update checkout.sh to fetch tags

### DIFF
--- a/bin/lib/checkout.sh
+++ b/bin/lib/checkout.sh
@@ -88,6 +88,7 @@ function checkout::initialize() {
   echo "/cloud" >> .git/info/sparse-checkout
   echo "/bin" >> .git/info/sparse-checkout
 
+  git fetch --quiet --tags
   git pull --quiet origin main
 
   popd > /dev/null


### PR DESCRIPTION
Since we are now tagging the cloud-deploy-infra repo with CiviForm releases, we need to fetch the tags on that repo to be able to check out that tag.