### PR TITLE
update comments for SAML_KEYSTORE_ACCOUNT_NAME

### DIFF
--- a/civiform_config.example.sh
+++ b/civiform_config.example.sh
@@ -182,8 +182,8 @@ export AWS_USERNAME=""
 
 # REQUIRED
 # An Azure Storage Account name for storing the SAML keystore secrets.
-# Only letters and numbers allowed.
-# e.g. "civiformsamlkeystoresecrets"
+# Only letters and numbers allowed. Must be between 3-24 characters.
+# e.g. "cfsamlkeystoresecrets"
 export SAML_KEYSTORE_ACCOUNT_NAME=""
 
 # REQUIRED


### PR DESCRIPTION
Adding some more helpful comments for the SAML_KEYSTORE_ACCOUNT_NAME to prevent people setting an invalid value.